### PR TITLE
Keep track of uploaded photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ rodeo upload <files...>
 ```
 ![](doc/rodeo-upload.png)
 
+Rodeo keeps track of which files it has uploaded in 
+`~/.config/rodeo/rodeo-uploaded-files.json` or in `.rodeo-uploaded-files.json`
+in the directory of the image file. This is controlled by the config setting
+`upload.store_uploaded_files_in_image_dir`.
+
 ### rodeo resize
 
 Resize image within a bounding box at a given quality which can be useful for social media or messaging.
@@ -118,6 +123,7 @@ flickr:
 # Configuration for `rodeo upload`
 upload:
    set_date_posted: false
+   store_uploaded_files_in_image_dir: false
 
 # Configuration for `rodeo resize`
 resize:
@@ -171,9 +177,10 @@ run of `rodeo`
 If these do not exist in `rodeo.yaml`, then they are added automatically on first
 run of `rodeo`
 
-| Property          | What it does                                                                         |
-| ----------------- | ------------------------------------------------------------------------------------ |
-| `set_date_posted` | If set to true, then the date posted is set to the date captured. Default is `false` |
+| Property          | What it does                                                                          |
+| ----------------- | ------------------------------------------------------------------------------------- |
+| `set_date_posted` | If set to `true`, then the date posted is set to the date captured. Default is `false`. |
+| `store_uploaded_files_in_image_dir` | If set to `true`, then the list of uploaded files is stored in `.rodeo-uploaded-files.json` within the images directory. Otherwise it is stored in `~/.config/rodeo`. Default is `false`.|
 
 ### Upload rules
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ rodeo upload <files...>
 Rodeo keeps track of which files it has uploaded in 
 `~/.config/rodeo/rodeo-uploaded-files.json` or in `.rodeo-uploaded-files.json`
 in the directory of the image file. This is controlled by the config setting
-`upload.store_uploaded_files_in_image_dir`.
+`upload.store_uploaded_list_in_image_dir`.
 
 ### rodeo resize
 
@@ -123,7 +123,7 @@ flickr:
 # Configuration for `rodeo upload`
 upload:
    set_date_posted: false
-   store_uploaded_files_in_image_dir: false
+   store_uploaded_list_in_image_dir: false
 
 # Configuration for `rodeo resize`
 resize:
@@ -180,7 +180,7 @@ run of `rodeo`
 | Property          | What it does                                                                          |
 | ----------------- | ------------------------------------------------------------------------------------- |
 | `set_date_posted` | If set to `true`, then the date posted is set to the date captured. Default is `false`. |
-| `store_uploaded_files_in_image_dir` | If set to `true`, then the list of uploaded files is stored in `.rodeo-uploaded-files.json` within the images directory. Otherwise it is stored in `~/.config/rodeo`. Default is `false`.|
+| `store_uploaded_list_in_image_dir` | If set to `true`, then the list of uploaded files is stored in `.rodeo-uploaded-files.json` within the images directory. Otherwise it is stored in `~/.config/rodeo`. Default is `false`.|
 
 ### Upload rules
 

--- a/commands/root.go
+++ b/commands/root.go
@@ -13,11 +13,10 @@ package commands
 
 import (
 	"fmt"
+	"github.com/akrabat/rodeo/internal"
 	"github.com/spf13/cobra"
-	"os"
-
-	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
+	"os"
 )
 
 var cfgFile string
@@ -68,15 +67,8 @@ func initConfig() {
 		// Use config file from the flag.
 		viper.SetConfigFile(cfgFile)
 	} else {
-		// Find home directory.
-		home, err := homedir.Dir()
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-
-		// Search config in home directory with name ".rodeo" (without extension).
-		viper.AddConfigPath(home + "/.config")
+		// Search config in ~/.config/rodeo directory with name "rodeo" (without extension).
+		viper.AddConfigPath(internal.ConfigDir())
 		viper.SetConfigName("rodeo")
 	}
 

--- a/commands/upload.go
+++ b/commands/upload.go
@@ -335,31 +335,18 @@ func getUploadedPhotoId(filename string, storeUploadFilesInImageDirectory bool) 
 
 // Record the filename of the image uploaded to `uploadedFilesBaseFilename`
 func recordUpload(filename string, photoId string, storeUploadFilesInImageDirectory bool) {
+	imageFilename := filepath.Base(filename)
 	uploadedFilesFilename := getUploadedFilesFilename(filename, storeUploadFilesInImageDirectory)
 	filenames := readUploadedFilesFile(uploadedFilesFilename)
 
-	// Append filename if it is not already in the list
-	imageFilename := filepath.Base(filename)
+	// If the imageFilename is already recorded, then there's nothing to do
 	if _, ok := filenames[imageFilename]; ok {
-		// Filename is already in the list
 		return
 	}
 
-	// Filename not in list, so add to list and save
+	// Filename not in list, so append to list and save
 	filenames[imageFilename] = photoId
-
-	// Convert to JSON
-	data, err := json.MarshalIndent(filenames, "", "  ")
-	if err != nil {
-		fmt.Println("error:", err)
-	}
-
-	// Write to disk
-	err = ioutil.WriteFile(uploadedFilesFilename, data, 0664)
-	if err != nil {
-		fmt.Printf("Error: Unable to write %s: $v", filepath.Base(uploadedFilesFilename), err)
-		return
-	}
+	writeUploadedFilesFile(filenames, uploadedFilesFilename)
 }
 
 // Read the uploaded files list from the `uploadedFilesFilename` and convert to a map from the JSON
@@ -382,4 +369,20 @@ func readUploadedFilesFile(uploadedFilesFilename string) map[string]string {
 	}
 
 	return filenames
+}
+
+// Write the uploaded files list to the `uploadedFilesFilename` in JSON format
+func writeUploadedFilesFile(filenames map[string]string, uploadedFilesFilename string) {
+	// Convert to JSON
+	data, err := json.MarshalIndent(filenames, "", "  ")
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+
+	// Write to disk
+	err = ioutil.WriteFile(uploadedFilesFilename, data, 0664)
+	if err != nil {
+		fmt.Printf("Error: Unable to write %s: $v", filepath.Base(uploadedFilesFilename), err)
+		return
+	}
 }

--- a/commands/upload.go
+++ b/commands/upload.go
@@ -99,7 +99,7 @@ func uploadFile(filename string, forceUpload bool) string {
 	}
 
 	// Has this image been uploaded before?
-	if uploadedPhotoId := getUploadedPhotoId(filename, config.Upload.StoreUploadFilesInImageDirectory); uploadedPhotoId != "" {
+	if uploadedPhotoId := getUploadedPhotoId(filename, config.Upload.StoreUploadFilesInImageDir); uploadedPhotoId != "" {
 		fmt.Print("This image has already been uploaded to Flickr.")
 		if forceUpload == true {
 			fmt.Println(" Forcing upload.")
@@ -272,7 +272,7 @@ func uploadFile(filename string, forceUpload bool) string {
 		return ""
 	}
 	photoId := response.ID
-	recordUpload(filename, photoId, config.Upload.StoreUploadFilesInImageDirectory)
+	recordUpload(filename, photoId, config.Upload.StoreUploadFilesInImageDir)
 	fmt.Printf("Uploaded photo '%s'\n", title)
 
 	// set date posted to the date that the photo was taken so that it's in the right place

--- a/commands/upload.go
+++ b/commands/upload.go
@@ -69,12 +69,12 @@ var uploadCmd = &cobra.Command{
 				photoIds = append(photoIds, photoId)
 			}
 		}
+
 		fmt.Println("All Done")
+		fmt.Printf("View: http://www.flickr.com/photos/%s'\n", viper.GetString("flickr.username"))
 
 		if len(photoIds) > 0 {
-			username := viper.GetString("flickr.username")
 			fmt.Printf("Edit: http://www.flickr.com/photos/upload/edit/?ids=%s\n", strings.Join(photoIds, ","))
-			fmt.Printf("View: http://www.flickr.com/photos/%s'\n", username)
 		}
 	},
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -23,8 +23,8 @@ type Flickr struct {
 }
 
 type Upload struct {
-	SetDatePosted  bool `mapstructure:"set_date_posted"`
-	StoreUploadFilesInImageDirectory  bool `mapstructure:"store_uploaded_files_in_image_directory"`
+	SetDatePosted              bool `mapstructure:"set_date_posted"`
+	StoreUploadFilesInImageDir bool `mapstructure:"store_uploaded_files_in_image_dir"`
 }
 
 type Resize struct {

--- a/internal/config.go
+++ b/internal/config.go
@@ -88,6 +88,10 @@ func setDefaults() {
 		viper.Set("upload.set_date_posted", false)
 	}
 
+	if viper.IsSet("upload.store_uploaded_list_in_image_dir") == false {
+		viper.Set("upload.store_uploaded_list_in_image_dir", false)
+	}
+
 	if viper.IsSet("cmd.convert") == false {
 		viper.Set("cmd.convert", "/usr/local/bin/convert")
 	}

--- a/internal/config.go
+++ b/internal/config.go
@@ -23,8 +23,8 @@ type Flickr struct {
 }
 
 type Upload struct {
-	SetDatePosted              bool `mapstructure:"set_date_posted"`
-	StoreUploadFilesInImageDir bool `mapstructure:"store_uploaded_files_in_image_dir"`
+	SetDatePosted             bool `mapstructure:"set_date_posted"`
+	StoreUploadListInImageDir bool `mapstructure:"store_uploaded_list_in_image_dir"`
 }
 
 type Resize struct {

--- a/internal/config.go
+++ b/internal/config.go
@@ -24,6 +24,7 @@ type Flickr struct {
 
 type Upload struct {
 	SetDatePosted  bool `mapstructure:"set_date_posted"`
+	StoreUploadFilesInImageDirectory  bool `mapstructure:"store_uploaded_files_in_image_directory"`
 }
 
 type Resize struct {

--- a/internal/configdir.go
+++ b/internal/configdir.go
@@ -1,0 +1,19 @@
+package internal
+
+import (
+	"fmt"
+	"github.com/mitchellh/go-homedir"
+	"os"
+)
+
+func ConfigDir() string {
+	// Find home directory.
+	home, err := homedir.Dir()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	return home + "/.config/rodeo"
+}
+

--- a/internal/strings.go
+++ b/internal/strings.go
@@ -1,6 +1,8 @@
 package internal
 
-import "strings"
+import (
+	"strings"
+)
 
 // from https://stackoverflow.com/a/45024302/23060
 func filter(src []string) (res []string) {


### PR DESCRIPTION
When we upload an image, check to see if we have already uploaded it. If we have, do not do anything. Allow the `-f` CLI modifier to override this check.

The list of files that we have uploaded can be stored in the same directory as the image file (as a hidden file) or in the `~/.config/rodeo` directory. This is controlled by the config setting `upload.store_uploaded_list_in_image_directory`.


Fixes #1