### PR TITLE
Set privacy on uploaded photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ rules:
         - {keyword4}
     action:
       delete: true # deletes {keyword3} and/or {keyword4}
+      privacy:
+        family: true
+        friends: true
+        public: true
 ```
 
 ### Resize configuration
@@ -199,9 +203,10 @@ For each rules there are up to four conditions and two actions:
 
 Each action is independent. One may exist or both.
 
-| Action   | What it does                                                                         |
-| -------- | ------------------------------------------------------------------------------------ |
-| `delete` | When `true`, deletes the keyword from the file so that it does not exist on Flickr.  |
-| `albums` | List of `id` and `name` for the albums that this image will be added to.             |
+| Action    | What it does                                                                         |
+| --------- | ------------------------------------------------------------------------------------ |
+| `delete`  | When `true`, deletes the keyword from the file so that it does not exist on Flickr.  |
+| `albums`  | List of `id` and `name` for the albums that this image will be added to.             |
+| `privacy` | Set the permissions on the photo for `family`, `friends` and `public`.               |
 
 

--- a/commands/upload.go
+++ b/commands/upload.go
@@ -126,6 +126,8 @@ func uploadFile(filename string, forceUpload bool, dryRun bool) string {
 	var keywordsToRemove []string
 	var keywordsToAdd []string
 	var albumsToAddTo []Album
+	var privacy Permissions
+	privacy.SetDefaults()
 
 	if config.Rules != nil {
 		for _, rule := range config.Rules {
@@ -187,6 +189,9 @@ func uploadFile(filename string, forceUpload bool, dryRun bool) string {
 				if rule.Action.Delete {
 					keywordsToRemove = append(keywordsToRemove, intersection...)
 				}
+				if rule.Action.Privacy != nil {
+					privacy = *rule.Action.Privacy
+				}
 				if len(rule.Action.Albums) > 0 {
 					for _, album := range rule.Action.Albums {
 						albumsToAddTo = append(albumsToAddTo, album)
@@ -210,6 +215,9 @@ func uploadFile(filename string, forceUpload bool, dryRun bool) string {
 		if len(keywordsToRemove) > 0 {
 			fmt.Printf("  - keywords to remove: %s\n", strings.Join(keywordsToRemove, ", "))
 		}
+
+		fmt.Printf("  - privacy will be set to: Family: %v, Friends: %v, Public: %v\n", privacy.Family, privacy.Friends, privacy.Public)
+
 		if len(albumsToAddTo) > 0 {
 			strs := make([]string, len(albumsToAddTo))
 			for i, a := range albumsToAddTo {
@@ -268,9 +276,9 @@ func uploadFile(filename string, forceUpload bool, dryRun bool) string {
 	params := flickr.UploadParams{
 		Title:       title,
 		Tags:        tags,
-		IsPublic:    true,
-		IsFamily:    true,
-		IsFriend:    true,
+		IsFamily:    privacy.Family,
+		IsFriend:    privacy.Friends,
+		IsPublic:    privacy.Public,
 		ContentType: 1, // photo
 		Hidden:      1, // not hidden
 		SafetyLevel: 1, // safe

--- a/internal/config.go
+++ b/internal/config.go
@@ -48,8 +48,20 @@ func (a Album) String() string {
 	return fmt.Sprintf("%s (%s)", a.Name, a.Id)
 }
 
+type Permissions struct {
+	Family  bool
+	Friends bool
+	Public  bool
+}
+func (p *Permissions) SetDefaults() {
+	p.Family = true
+	p.Friends = true
+	p.Public = true
+}
+
 type Action struct {
 	Delete bool
+	Privacy *Permissions
 	Albums []Album
 }
 type Rules struct {


### PR DESCRIPTION
Add the new action `privacy` which takes three boolean children for `family`, `friends` and `public`. When this action is invoked, the permissions on the Flickr photo will be set appropriately.

Fixed #6.