### PR TITLE
Add --filter to listalbums

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ rodeo info <files...>
 | --- | --- |
 | `rodeo viewconfig` | Display Rodeo's configuration. |
 | `rodeo authenticate` | Authenticate with Flickr. |
-| `rodeo listalbums` | List albums (helpful to find album IDs. |
+| `rodeo listalbums` | List albums (helpful to find album IDs. Accepts `--filter` to search the results. |
 
 
 ## Installation


### PR DESCRIPTION
Allow the list of albums to be filtered using the `--filter` flag. This is case-insensitive, but we if it turns out that sometimes case-sensitivity is required, we could all a new flag or something.

Fixes #16 