### PR TITLE
Do not error when --album is not used

### DIFF
--- a/commands/upload.go
+++ b/commands/upload.go
@@ -230,7 +230,7 @@ func uploadFile(filename string, forceUpload bool, dryRun bool, album Album) str
 			for i, a := range albumsToAddTo {
 				strs[i] = a.Name
 			}
-			fmt.Printf("  - albums to add to: %s\n", strings.Join(strs, ", "))
+			fmt.Printf("  - albums to add to: \"%s\"\n", strings.Join(strs, "\", \""))
 		}
 		fmt.Printf("\n")
 	}

--- a/commands/upload.go
+++ b/commands/upload.go
@@ -74,6 +74,7 @@ var uploadCmd = &cobra.Command{
 		albumId, _ := cmd.Flags().GetString("album")
 		album, err := getAlbum(albumId)
 		if err != nil {
+			fmt.Printf("Could not find album %s\n", albumId)
 			fmt.Println(err)
 			return
 		}
@@ -435,7 +436,13 @@ func writeUploadedListFile(filenames map[string]string, uploadedListFilename str
 	}
 }
 
+// Retrieve album from Flickr's API so that we have the full information about it
 func getAlbum(albumId string) (Album, error) {
+	if albumId == "" {
+		// No album to look for! So we return an empty album
+		return Album{}, nil
+	}
+
 	client, err := getFlickrClient()
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
When `--album` is not set, we should not error! 

Also while we're here, enclose album name with quotes when printing as some album names may have commas in them.
