### PR TITLE
Allow selection by name with --album parameter

### DIFF
--- a/commands/listalbums.go
+++ b/commands/listalbums.go
@@ -50,14 +50,14 @@ func listAlbums(filter string) {
 		return
 	}
 
-	albums := GetAlbums(flickr, filter)
+	photosets := GetPhotosets(flickr, filter)
 
-	if len(albums) == 0 {
+	if len(photosets) == 0 {
 		fmt.Println("No albums found")
 		return
 	}
 
-	for i, album := range albums {
+	for i, album := range photosets {
 		fmt.Printf("%3d: %s (%s)\n", i+1, album.Title, album.Id)
 	}
 }

--- a/commands/listalbums.go
+++ b/commands/listalbums.go
@@ -15,9 +15,6 @@ import (
 	"fmt"
 	. "github.com/akrabat/rodeo/internal"
 	"github.com/spf13/cobra"
-	"gopkg.in/masci/flickr.v2"
-	"gopkg.in/masci/flickr.v2/photosets"
-	"strings"
 )
 
 func init() {
@@ -47,39 +44,20 @@ func listAlbums(filter string) {
 	}
 	fmt.Print("\n")
 
-	config := GetConfig()
-	apiKey := config.Flickr.ApiKey
-	apiSecret := config.Flickr.ApiSecret
-	oauthToken := config.Flickr.OauthToken
-	oauthTokenSecret := config.Flickr.OauthSecret
-	userId := config.Flickr.UserId
-
-	if apiKey == "" || apiSecret == "" || oauthToken == "" || oauthTokenSecret == "" || userId == "" {
-		fmt.Println("Unable to continue. Please run the 'rodeo authenticate' command first")
-	}
-
-	client := flickr.NewFlickrClient(apiKey, apiSecret)
-	client.OAuthToken = oauthToken
-	client.OAuthTokenSecret = oauthTokenSecret
-
-	response, err := photosets.GetList(client, true, userId, 1)
+	flickr, err := GetFlickrClient()
 	if err != nil {
-		fmt.Println(err)
+		fmt.Printf("Error: %v", err)
 		return
 	}
 
-	albums := response.Photosets;
-	if albums.Pages > 1 {
-		fmt.Println("More albums are available, but getting the second page is not implemented yet")
+	albums := GetAlbums(flickr, filter)
+
+	if len(albums) == 0 {
+		fmt.Println("No albums found")
+		return
 	}
 
-	index := 0
-	for _, album := range albums.Items {
-		if strings.Contains(strings.ToLower(album.Title), strings.ToLower(filter)) {
-			index += 1
-			fmt.Printf("%3d: %s (%s)\n", index, album.Title, album.Id)
-		}
+	for i, album := range albums {
+		fmt.Printf("%3d: %s (%s)\n", i+1, album.Title, album.Id)
 	}
-
-	fmt.Println("")
 }

--- a/commands/upload.go
+++ b/commands/upload.go
@@ -461,8 +461,8 @@ func getAlbums(albumId string) ([]Album, error) {
 }
 
 // Display the available albums and allow the user to select one
-func chooseAlbumFromList(albums []Album, albumId string) (Album, error) {
-	fmt.Printf("Available albums that match \"%s\":\n", albumId)
+func chooseAlbumFromList(albums []Album, searchTerm string) (Album, error) {
+	fmt.Printf("Available albums that match \"%s\":\n", searchTerm)
 	for i, album := range albums {
 		fmt.Printf("%3d: %s (%s)\n", i+1, album.Name, album.Id)
 	}

--- a/commands/upload.go
+++ b/commands/upload.go
@@ -442,7 +442,7 @@ func getAlbums(albumId string) ([]Album, error) {
 		return []Album{}, err
 	}
 
-	photosets := GetAlbums(client, albumId)
+	photosets := GetPhotosets(client, albumId)
 	if len(photosets) == 0 {
 		// No photosets founds
 		return []Album{}, errors.New(fmt.Sprintf("could not find album %s", albumId))

--- a/commands/upload.go
+++ b/commands/upload.go
@@ -14,7 +14,6 @@ package commands
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	. "github.com/akrabat/rodeo/internal"
 	"github.com/spf13/cobra"
@@ -261,7 +260,7 @@ func uploadFile(filename string, forceUpload bool, dryRun bool, album Album) str
 	// Upload file to Flickr
 	fmt.Println("Uploading photo to Flickr")
 
-	client, err := getFlickrClient()
+	client, err := GetFlickrClient()
 	if err != nil {
 		fmt.Println(err)
 		return ""
@@ -332,25 +331,6 @@ func uploadFile(filename string, forceUpload bool, dryRun bool, album Album) str
 	fmt.Printf("View this photo: http://www.flickr.com/photos/%s/%s\n", config.Flickr.Username, photoId)
 	fmt.Println("")
 	return photoId
-}
-
-func getFlickrClient() (*flickr.FlickrClient, error) {
-	config := GetConfig()
-
-	apiKey := config.Flickr.ApiKey
-	apiSecret := config.Flickr.ApiSecret
-	oauthToken := config.Flickr.OauthToken
-	oauthTokenSecret := config.Flickr.OauthSecret
-	if apiKey == "" || apiSecret == "" || oauthToken == "" || oauthTokenSecret == "" {
-		fmt.Println("Unable to continue. Please run the 'rodeo authenticate' command first")
-		return nil, errors.New("credentials not set")
-	}
-
-	client := flickr.NewFlickrClient(apiKey, apiSecret)
-	client.OAuthToken = oauthToken
-	client.OAuthTokenSecret = oauthTokenSecret
-
-	return client, nil
 }
 
 func getUploadedListFilename(imageFilename string, storeUploadListInImageDirectory bool) string {
@@ -443,7 +423,7 @@ func getAlbum(albumId string) (Album, error) {
 		return Album{}, nil
 	}
 
-	client, err := getFlickrClient()
+	client, err := GetFlickrClient()
 	if err != nil {
 		fmt.Println(err)
 		return Album{}, err
@@ -463,5 +443,4 @@ func getAlbum(albumId string) (Album, error) {
 	}
 
 	return album, nil
-
 }

--- a/internal/flickr.go
+++ b/internal/flickr.go
@@ -32,7 +32,7 @@ func GetFlickrClient() (*flickr.FlickrClient, error) {
 }
 
 // Get the list of Flickr photosets as a slice
-func GetAlbums(client *flickr.FlickrClient, filter string) []photosets.Photoset {
+func GetPhotosets(client *flickr.FlickrClient, filter string) []photosets.Photoset {
 	config := GetConfig()
 	userId := config.Flickr.UserId
 

--- a/internal/flickr.go
+++ b/internal/flickr.go
@@ -53,7 +53,9 @@ func GetAlbums(client *flickr.FlickrClient, filter string) []photosets.Photoset 
 	var albums []photosets.Photoset
 
 	for _, photo := range photos.Items{
-		if strings.Contains(strings.ToLower(photo.Title), strings.ToLower(filter)) {
+		if photo.Id == filter {
+			albums = append(albums, photo)
+		} else if strings.Contains(strings.ToLower(photo.Title), strings.ToLower(filter)) {
 			albums = append(albums, photo)
 		}
 	}

--- a/internal/flickr.go
+++ b/internal/flickr.go
@@ -1,0 +1,62 @@
+// Helpful Flickr API operations
+package internal
+
+import (
+	"errors"
+	"fmt"
+	"gopkg.in/masci/flickr.v2"
+	"gopkg.in/masci/flickr.v2/photosets"
+	"strings"
+)
+
+func GetFlickrClient() (*flickr.FlickrClient, error) {
+	config := GetConfig()
+
+	apiKey := config.Flickr.ApiKey
+	apiSecret := config.Flickr.ApiSecret
+	oauthToken := config.Flickr.OauthToken
+	oauthTokenSecret := config.Flickr.OauthSecret
+	if apiKey == "" || apiSecret == "" || oauthToken == "" || oauthTokenSecret == "" {
+		fmt.Println("Unable to continue. Please run the 'rodeo authenticate' command first")
+		return nil, errors.New("credentials not set")
+	}
+
+	client := flickr.NewFlickrClient(apiKey, apiSecret)
+	if client == nil {
+		return nil, errors.New("unable to connect to Flickr")
+	}
+	client.OAuthToken = oauthToken
+	client.OAuthTokenSecret = oauthTokenSecret
+
+	return client, nil
+}
+
+// Get the list of Flickr photosets as a slice
+func GetAlbums(client *flickr.FlickrClient, filter string) []photosets.Photoset {
+	config := GetConfig()
+	userId := config.Flickr.UserId
+
+	response, err := photosets.GetList(client, true, userId, 1)
+	if err != nil {
+		fmt.Println(err)
+		return []photosets.Photoset{}
+	}
+
+	photos := response.Photosets
+
+	// Todo: check for pagination
+	if photos.Pages > 1 {
+		fmt.Println("More albums are available, but getting the second page is not implemented yet")
+	}
+
+	// Filter if required
+	var albums []photosets.Photoset
+
+	for _, photo := range photos.Items{
+		if strings.Contains(strings.ToLower(photo.Title), strings.ToLower(filter)) {
+			albums = append(albums, photo)
+		}
+	}
+
+	return albums
+}


### PR DESCRIPTION
When uploading to an album using `--upload`, allow the parameter to be the name of the album.

We will then look up the album's Flickr ID and use that. If there is more than one available choice, then allow the user to select  the intended album to attach this image to.

Fixes #21 