### PR TITLE
Prompt for new album if none found

### DIFF
--- a/internal/metadata.go
+++ b/internal/metadata.go
@@ -68,7 +68,7 @@ func GetImageInfo(filename string, exiftool string) (*ImageInfo, error) {
 
 	out, err := cmd.Output()
 	if err != nil {
-		fmt.Println("Error: ", err)
+		fmt.Printf("%s\n", err.(*exec.ExitError).Stderr)
 		return nil, err
 	}
 


### PR DESCRIPTION
If no album is found for the argument to `--album` then prompt the user to choose a name for a new album, with a default of the argument.

Also fix an error message when GetImageInfo() fails.

Partly addresses #22
