### PR TITLE
Set version number to tag when releasing via GH actions

### DIFF
--- a/build-executables.sh
+++ b/build-executables.sh
@@ -41,7 +41,9 @@ do
     fi
 
     echo "Building release/$output_name..."
-    env GOOS=$GOOS GOARCH=$GOARCH go build -o release/$output_name
+    env GOOS=$GOOS GOARCH=$GOARCH go build \
+      -ldflags "-X github.com/akrabat/rodeo/commands.Version=$version" \
+      -o release/$output_name
     if [ $? -ne 0 ]; then
         echo 'An error has occurred! Aborting the script execution...'
         exit 1

--- a/commands/root.go
+++ b/commands/root.go
@@ -19,11 +19,12 @@ import (
 	"os"
 )
 
+var Version = "dev-build"
 var cfgFile string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Version: "0.4-dev",
+	Version: Version,
 	Use:     "rodeo",
 	Short:   "Flickr command line tool",
 	Long: `A command line tool to work with Flickr and images.

--- a/doc/RELEASE_PROCESS.md
+++ b/doc/RELEASE_PROCESS.md
@@ -1,17 +1,17 @@
 # Release Process
 
-1. Ensure milestone for correct version number exists.
-2. Update version number in root.go, PR and merge to `main`.
-3. Assign all closed PRs for this release to the milestone.
-4. Ensure `main` is clean locally.
-5. Create changelog using `phly/changelog-generator` and copy to clipboard:
+1. Ensure that the milestone for correct version number exists on GitHub.
+2. Assign all closed PRs for this release to the milestone.
+3. Ensure `main` is clean locally.
+4. Create changelog using `phly/changelog-generator` and copy to clipboard:
     
         changelog-generator -u akrabat -r rodeo -m 2 | pbcopy
 
-5. Tag with new version: `git tag -s 0.1.1` and paste in changelog.
+5. Tag the new version: `git tag -s 0.1.1` and paste in changelog.
 6. Push tag to GitHub: `git push --follow-tags`.
 7. Close milestone and create next one.
 8. Create a [Release](https://github.com/akrabat/rodeo/releases) with the tag name as the release title.
 
-    This will automatically run a GitHub Action that creates the binaries for this release.
+   This will automatically run a GitHub Action that creates the binaries for this release with
+   the tag set as the version number as described by `./rodeo --version`.
 


### PR DESCRIPTION
We now use a global variable for the Rodeo version number and set this using `ldflags -X` in `build-executables.sh`. This means that when the GH action builds the binaries on a new release, the internal version number is correctly set automatically for us. Also update `RELEASE_PROCRESS.md`.

Closes #39.