### PR TITLE
Accept Subject, Title and Description metadata fields

### DIFF
--- a/commands/authenticate.go
+++ b/commands/authenticate.go
@@ -30,7 +30,7 @@ func init() {
 var authenticateCmd = &cobra.Command{
 	Use:   "authenticate",
 	Short: "Authenticate with Flickr",
-	Long: "Authenticate with Flickr",
+	Long:  "Authenticate with Flickr",
 	Run: func(cmd *cobra.Command, args []string) {
 		authenticate()
 	},
@@ -69,7 +69,6 @@ func authenticate() {
 
 	fmt.Printf("Saved your Flickr API Key\n\n")
 
-
 	apiSecret := viper.GetString("flickr.api_secret")
 	if apiSecret != "" {
 		fmt.Println("Please provide your Flickr API Secret (Leave blank to use current secret)")
@@ -99,7 +98,6 @@ func authenticate() {
 	}
 
 	fmt.Printf("Saved your Flickr API Secret\n\n")
-
 
 	// Authenticate
 	client := flickr.NewFlickrClient(apiKey, apiSecret)

--- a/commands/listalbums.go
+++ b/commands/listalbums.go
@@ -26,7 +26,7 @@ func init() {
 var listAlbumsCmd = &cobra.Command{
 	Use:   "listalbums",
 	Short: "List Flickr albums",
-	Long: `List Flickr albums`,
+	Long:  `List Flickr albums`,
 	Run: func(cmd *cobra.Command, args []string) {
 		filter, err := cmd.Flags().GetString("filter")
 		if err != nil {

--- a/commands/upload.go
+++ b/commands/upload.go
@@ -16,18 +16,19 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	. "github.com/akrabat/rodeo/internal"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"gopkg.in/masci/flickr.v2"
-	"gopkg.in/masci/flickr.v2/photos"
-	"gopkg.in/masci/flickr.v2/photosets"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	. "github.com/akrabat/rodeo/internal"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"gopkg.in/masci/flickr.v2"
+	"gopkg.in/masci/flickr.v2/photos"
+	"gopkg.in/masci/flickr.v2/photosets"
 )
 
 const uploadedListBaseFilename = "rodeo-uploaded-files.json"
@@ -293,8 +294,11 @@ func uploadFile(filename string, forceUpload bool, dryRun bool, album *Album) st
 			}
 			fmt.Printf("  - albums to add to: \"%s\"\n", strings.Join(strs, "\", \""))
 		}
-		fmt.Printf("\n")
 	}
+
+	title := strings.Trim(info.Title, " ")
+	fmt.Printf("  - title will be set to \"%s\"\n", title)
+	fmt.Printf("\n")
 
 	// All ready to process now
 	if dryRun {
@@ -328,7 +332,6 @@ func uploadFile(filename string, forceUpload bool, dryRun bool, album *Album) st
 		return ""
 	}
 
-	title := strings.Trim(info.Title, " ")
 	if title == "" {
 		// no title - use filename (without extension)
 		title = filepath.Base(filename)
@@ -532,7 +535,7 @@ func getAlbums(albumId string) ([]Album, error) {
 	// At least one photoset found
 	for _, photo := range photosets {
 		album := Album{
-			Id: photo.Id,
+			Id:   photo.Id,
 			Name: photo.Title,
 		}
 		albums = append(albums, album)
@@ -568,7 +571,7 @@ func promptForNewAlbum(albumId string) (*Album, error) {
 	reader := bufio.NewReader(os.Stdin)
 	chosenAlbumName, err := reader.ReadString('\n')
 	if err != nil {
-		return  nil, err
+		return nil, err
 	}
 	chosenAlbumName = strings.TrimSuffix(chosenAlbumName, "\n")
 

--- a/commands/viewconfig.go
+++ b/commands/viewconfig.go
@@ -97,6 +97,5 @@ func viewConfig() {
 			fmt.Printf("      Add to album%v: %v\n", PluralS(albums), strings.Join(strs, ", "))
 		}
 
-
 	}
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -8,18 +8,18 @@ import (
 var config *Config
 
 type Command struct {
-	Convert string
+	Convert  string
 	Exiftool string
 }
 
 type Flickr struct {
-	ApiKey string `mapstructure:"api_key"`
-	ApiSecret string `mapstructure:"api_secret"`
-	Fullname string `mapstructure:"full_name"`
-	OauthToken string `mapstructure:"oauth_token"`
+	ApiKey      string `mapstructure:"api_key"`
+	ApiSecret   string `mapstructure:"api_secret"`
+	Fullname    string `mapstructure:"full_name"`
+	OauthToken  string `mapstructure:"oauth_token"`
 	OauthSecret string `mapstructure:"oauth_token_secret"`
-	UserId string `mapstructure:"user_nsid"`
-	Username string `mapstructure:"username"`
+	UserId      string `mapstructure:"user_nsid"`
+	Username    string `mapstructure:"username"`
 }
 
 type Upload struct {
@@ -30,20 +30,21 @@ type Upload struct {
 type Resize struct {
 	Method  string
 	Quality string
-	Scale string
+	Scale   string
 }
 
 type Condition struct {
-	ExcludesAll []string  `mapstructure:"excludes_all"` // list of keywords that must all not exist on image
-	ExcludesAny []string  `mapstructure:"excludes_any"` // list of keywords where any one must not exist on image
-	IncludesAll []string  `mapstructure:"includes_all"` // list of keywords that must all exist on image
-	IncludesAny []string  `mapstructure:"includes_any"` // list of keywords where any one must exist on image
+	ExcludesAll []string `mapstructure:"excludes_all"` // list of keywords that must all not exist on image
+	ExcludesAny []string `mapstructure:"excludes_any"` // list of keywords where any one must not exist on image
+	IncludesAll []string `mapstructure:"includes_all"` // list of keywords that must all exist on image
+	IncludesAny []string `mapstructure:"includes_any"` // list of keywords where any one must exist on image
 }
 
 type Album struct {
 	Id   string
 	Name string
 }
+
 func (a Album) String() string {
 	return fmt.Sprintf("%s (%s)", a.Name, a.Id)
 }
@@ -53,6 +54,7 @@ type Permissions struct {
 	Friends bool
 	Public  bool
 }
+
 func (p *Permissions) SetDefaults() {
 	p.Family = true
 	p.Friends = true
@@ -60,21 +62,21 @@ func (p *Permissions) SetDefaults() {
 }
 
 type Action struct {
-	Delete bool
+	Delete  bool
 	Privacy *Permissions
-	Albums []Album
+	Albums  []Album
 }
 type Rules struct {
 	Condition Condition
-	Action     Action
+	Action    Action
 }
 
 type Config struct {
-	Cmd Command
+	Cmd    Command
 	Flickr Flickr
 	Upload Upload
 	Resize Resize
-	Rules []Rules
+	Rules  []Rules
 }
 
 func GetConfig() *Config {

--- a/internal/configdir.go
+++ b/internal/configdir.go
@@ -16,4 +16,3 @@ func ConfigDir() string {
 
 	return home + "/.config/rodeo"
 }
-

--- a/internal/flickr.go
+++ b/internal/flickr.go
@@ -52,7 +52,7 @@ func GetPhotosets(client *flickr.FlickrClient, filter string) []photosets.Photos
 	// Filter if required
 	var albums []photosets.Photoset
 
-	for _, photo := range photos.Items{
+	for _, photo := range photos.Items {
 		if photo.Id == filter {
 			albums = append(albums, photo)
 		} else if strings.Contains(strings.ToLower(photo.Title), strings.ToLower(filter)) {

--- a/internal/plural.go
+++ b/internal/plural.go
@@ -15,4 +15,3 @@ func PluralS(s interface{}) string {
 	}
 	return "s"
 }
-

--- a/internal/strings.go
+++ b/internal/strings.go
@@ -26,7 +26,6 @@ func Intersection(section1, section2 []string) (intersection []string) {
 	return
 }
 
-
 // From: https://stackoverflow.com/a/56377243/23060
 func Difference(a, b []string) []string {
 	temp := map[string]int{}


### PR DESCRIPTION
- If Keywords is blank, check Subject
- If Title is blank, check Object Name
- If Description is blank, check Caption-Abstract

This is required because Apple Photos in macOS Tahoe no longer populatesthe Object Name, Keywords or Caption-Abstract fields.